### PR TITLE
Typo in creating the single cell gate in the vignette

### DIFF
--- a/vignettes/CytoExploreR.Rmd
+++ b/vignettes/CytoExploreR.Rmd
@@ -97,7 +97,7 @@ cyto_gate_draw(gs,
 cyto_gate_draw(gs,
                parent = "Cells",
                alias = "Single Cells",
-               channels = c("FSC-A", "SSC-A"))
+               channels = c("FSC-A", "FSC-H"))
 ```
 
 ```{r, echo=FALSE, fig.align="center", out.width = '98%'}


### PR DESCRIPTION
SSC-A > FSC-H when creating the single cell gate