### PR TITLE
Unnecessary iteration in the parameter description

### DIFF
--- a/R/cyto_stats_compute.R
+++ b/R/cyto_stats_compute.R
@@ -23,7 +23,7 @@
 #'   statistics.
 #' @param stat name of the statistic to calculate, options include
 #'   \code{"count"}, \code{"freq"}, \code{"median"}, \code{"mode"},
-#'   \code{"mean"}, \code{"geo mean"}, \code{"CV"}, or \code{"freq"}.
+#'   \code{"mean"}, \code{"geo mean"}, or \code{"CV"}.
 #' @param gate object of class \code{rectangleGate}, \code{polygonGate} or
 #'   \code{ellipsoidGate} to apply to \code{flowFrame} or \code{flowSet} objects
 #'   prior to computing statistics.


### PR DESCRIPTION
In the cyto_stats_compute() "stat" parameter description "freq" was unnecessarily mentioned 2 times.